### PR TITLE
[#33] 반찬 상세페이지 API 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/sidedish/business/dao/BestDishDaoDion.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/business/dao/BestDishDaoDion.java
@@ -1,0 +1,14 @@
+package kr.codesquad.sidedish.business.dao;
+
+import kr.codesquad.sidedish.business.dto.CategoryDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class BestDishDaoDion implements BestDishDao {
+    @Override
+    public List<CategoryDto> findBestDishes() {
+        return null;
+    }
+}

--- a/BE/src/main/java/kr/codesquad/sidedish/business/dao/DishDaoDion.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/business/dao/DishDaoDion.java
@@ -1,0 +1,51 @@
+package kr.codesquad.sidedish.business.dao;
+
+import kr.codesquad.sidedish.business.dto.DishDto;
+import kr.codesquad.sidedish.common.error.exception.DishNotFoundException;
+import kr.codesquad.sidedish.common.util.NamedParameterOptionalJdbcTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class DishDaoDion implements DishDao {
+    private static final Logger log = LoggerFactory.getLogger(DishDaoDion.class);
+
+    private final NamedParameterOptionalJdbcTemplate namedParameterJdbcTemplate;
+
+    public DishDaoDion(DataSource dataSource) {
+        this.namedParameterJdbcTemplate = new NamedParameterOptionalJdbcTemplate(dataSource);
+    }
+
+    @Override
+    public DishDto findDishById(Long id) {
+        log.debug("id: {}", id);
+
+        String dishDetailSql = "SELECT img.url AS top_image, sd.description AS description, FORMAT(sd.point, 0) AS point, sd.delivery_info AS delivery_info, sd.delivery_fee AS delivery_fee, FORMAT(sd.normal_price, 0) AS normal_price, FORMAT(sd.sale_price, 0) AS sale_price FROM side_dish AS sd INNER JOIN image AS img ON img.id = sd.top_image WHERE sd.id = :id;";
+        String thumbImageSql = "SELECT img.url FROM image AS img LEFT OUTER JOIN side_dish AS sd ON img.side_dish = sd.id WHERE img.thumb_image_order IS NOT NULL AND sd.id = :id ORDER BY img.thumb_image_order;";
+        String detailSectionImageSql = "SELECT img.url FROM image AS img LEFT OUTER JOIN side_dish AS sd ON img.side_dish = sd.id WHERE img.detail_section_image_order IS NOT NULL AND sd.id = :id ORDER BY img.detail_section_image_order;";
+
+        SqlParameterSource parameters = new MapSqlParameterSource().addValue("id", id);
+
+        DishDto dishDto = namedParameterJdbcTemplate.queryForOptionalObject(dishDetailSql, parameters, (rs, rowNum) -> {
+            DishDto dto = new DishDto();
+            dto.setTopImage(rs.getString("top_image"));
+            dto.setDescription(rs.getString("description"));
+            dto.setPoint(rs.getString("point"));
+            dto.setDeliveryInfo(rs.getString("delivery_info"));
+            dto.setDeliveryFee(rs.getString("delivery_fee"));
+            dto.setNormalPrice(rs.getString("normal_price"));
+            dto.setSalePrice(rs.getString("sale_price"));
+            return dto;
+        }).orElseThrow(DishNotFoundException::new);
+
+        dishDto.setThumbImages(namedParameterJdbcTemplate.queryForList(thumbImageSql, parameters, String.class));
+        dishDto.setDetailSectionImages(namedParameterJdbcTemplate.queryForList(detailSectionImageSql, parameters, String.class));
+
+        return dishDto;
+    }
+}

--- a/BE/src/main/java/kr/codesquad/sidedish/business/dao/FoodTypeDaoDion.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/business/dao/FoodTypeDaoDion.java
@@ -1,0 +1,14 @@
+package kr.codesquad.sidedish.business.dao;
+
+import kr.codesquad.sidedish.business.dto.DishOverviewDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class FoodTypeDaoDion implements FoodTypeDao {
+    @Override
+    public List<DishOverviewDto> findDishesByFoodTypeId(Long foodTypeId) {
+        return null;
+    }
+}

--- a/BE/src/main/java/kr/codesquad/sidedish/business/dto/DishDto.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/business/dto/DishDto.java
@@ -86,4 +86,9 @@ public class DishDto {
     public void setDetailSectionImages(List<String> detailSectionImages) {
         this.detailSectionImages = detailSectionImages;
     }
+
+    @Override
+    public String toString() {
+        return "DishDto{" + "topImage='" + topImage + '\'' + ", description='" + description + '\'' + ", point='" + point + '\'' + ", deliveryInfo='" + deliveryInfo + '\'' + ", deliveryFee='" + deliveryFee + '\'' + ", normalPrice='" + normalPrice + '\'' + ", salePrice='" + salePrice + '\'' + ", thumbImages=" + thumbImages + ", detailSectionImages=" + detailSectionImages + '}';
+    }
 }

--- a/BE/src/main/java/kr/codesquad/sidedish/common/error/ErrorCode.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/common/error/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(404, "U001", " 해당 사용자가 존재하지 않습니다."),
     LOGIN_REQUIRED(401, "U002", " 로그인을 해주세요."),
+    // Dish
+    DISH_NOT_FOUND(404, "D001", " 해당 반찬은 존재하지 않아요!")
     ;
 
     private final String code;

--- a/BE/src/main/java/kr/codesquad/sidedish/common/error/exception/DishNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/common/error/exception/DishNotFoundException.java
@@ -1,0 +1,15 @@
+package kr.codesquad.sidedish.common.error.exception;
+
+import kr.codesquad.sidedish.common.error.ErrorCode;
+
+public class DishNotFoundException extends EntityNotFoundException {
+
+    public DishNotFoundException() {
+        super(ErrorCode.DISH_NOT_FOUND);
+    }
+
+    public DishNotFoundException(String message) {
+        super(message, ErrorCode.DISH_NOT_FOUND);
+    }
+
+}

--- a/BE/src/main/java/kr/codesquad/sidedish/common/util/NamedParameterOptionalJdbcTemplate.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/common/util/NamedParameterOptionalJdbcTemplate.java
@@ -1,0 +1,40 @@
+package kr.codesquad.sidedish.common.util;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SingleColumnRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class NamedParameterOptionalJdbcTemplate extends NamedParameterJdbcTemplate {
+    public NamedParameterOptionalJdbcTemplate(DataSource dataSource) {
+        super(dataSource);
+    }
+
+    public <T> Optional<T> queryForOptionalObject(String sql, SqlParameterSource parameterSource, RowMapper<T> rowMapper) {
+        List<T> results = getJdbcOperations().query(getPreparedStatementCreator(sql, parameterSource), rowMapper);
+
+        if (results.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(results.iterator().next());
+        }
+    }
+
+    public <T> Optional<T> queryForOptionalObject(String sql, Map<String, ?> paramMap, RowMapper<T> rowMapper) {
+        return queryForOptionalObject(sql, new MapSqlParameterSource(paramMap), rowMapper);
+    }
+
+    public <T> Optional<T> queryForOptionalObject(String sql, SqlParameterSource parameterSource, Class<T> requiredType) {
+        return queryForOptionalObject(sql, parameterSource, new SingleColumnRowMapper<>(requiredType));
+    }
+
+    public <T> Optional<T> queryForOptionalObject(String sql, Map<String, ?> paramMap, Class<T> requiredType) {
+        return queryForOptionalObject(sql, paramMap, new SingleColumnRowMapper<>(requiredType));
+    }
+}

--- a/BE/src/test/java/kr/codesquad/sidedish/business/dao/DishDaoDionTest.java
+++ b/BE/src/test/java/kr/codesquad/sidedish/business/dao/DishDaoDionTest.java
@@ -1,0 +1,36 @@
+package kr.codesquad.sidedish.business.dao;
+
+import kr.codesquad.sidedish.business.dto.DishDto;
+import kr.codesquad.sidedish.common.error.exception.DishNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class DishDaoDionTest {
+    private static final Logger log = LoggerFactory.getLogger(DishDaoDionTest.class);
+
+    @Autowired
+    private DishDao dishDao;
+
+    @Test
+    void 잘와요() {
+        DishDto dto = dishDao.findDishById(1L);
+        assertThat(dto).isNotNull();
+        log.debug("dto: {}", dto);
+    }
+
+    @Test
+    void 잘안와요() {
+        assertThatThrownBy(() -> {
+            DishDto dto = dishDao.findDishById(30L);
+        }).isInstanceOf(DishNotFoundException.class)
+          .hasMessageContaining(" 해당 반찬은 존재하지 않아요!");
+    }
+
+}


### PR DESCRIPTION
### 반찬 상세페이지 API를 구현합니다.

- 해당하는 반찬을 찾지 못했을 경우 출력할 에러를 생성합니다.
- NamedParameterJdbcTemplate이 원하는 기능을 제공하지 않아, 상속하여 기능을 확장하는 클래스를 구현하였습니다.
- 상세페이지 Dao를 개발하였습니다. Optional을 이용하여, 값이 존재하지 않을경우, 예외를 리턴합니다.
