### PR TITLE
[#57] refactor: queryForOptionalObject 개선

### DIFF
--- a/BE/src/main/java/kr/codesquad/sidedish/common/util/NamedParameterOptionalJdbcTemplate.java
+++ b/BE/src/main/java/kr/codesquad/sidedish/common/util/NamedParameterOptionalJdbcTemplate.java
@@ -7,7 +7,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 import javax.sql.DataSource;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -17,13 +16,7 @@ public class NamedParameterOptionalJdbcTemplate extends NamedParameterJdbcTempla
     }
 
     public <T> Optional<T> queryForOptionalObject(String sql, SqlParameterSource parameterSource, RowMapper<T> rowMapper) {
-        List<T> results = getJdbcOperations().query(getPreparedStatementCreator(sql, parameterSource), rowMapper);
-
-        if (results.isEmpty()) {
-            return Optional.empty();
-        } else {
-            return Optional.ofNullable(results.iterator().next());
-        }
+        return getJdbcOperations().query(getPreparedStatementCreator(sql, parameterSource), rowMapper).stream().findFirst();
     }
 
     public <T> Optional<T> queryForOptionalObject(String sql, Map<String, ?> paramMap, RowMapper<T> rowMapper) {


### PR DESCRIPTION
이제 Optional.empty() 등을 사용하는 대신 stream API의 findFirst()를 이용합니다.
Close #57 Issue.
